### PR TITLE
fix: correct EXPOSE port and convert JupyterLab to JupyterHub

### DIFF
--- a/JupyterHub/Dockerfile
+++ b/JupyterHub/Dockerfile
@@ -47,10 +47,13 @@ COPY requirements.txt .
 RUN pip3 install --upgrade pip && \
     pip3 install --no-cache-dir -r requirements.txt
 
-RUN mkdir -p /srv/notebooks
+RUN mkdir -p /data /etc/jupyterhub /srv/notebooks
+
+COPY jupyterhub_config.py /etc/jupyterhub/jupyterhub_config.py
+COPY notebooks/ /srv/notebooks/
 
 WORKDIR /srv/notebooks
 
-EXPOSE 8888
+EXPOSE 8000
 
-CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--NotebookApp.token=''", "--notebook-dir=/srv/notebooks"]
+CMD ["jupyterhub", "--config=/etc/jupyterhub/jupyterhub_config.py"]

--- a/JupyterHub/requirements.txt
+++ b/JupyterHub/requirements.txt
@@ -1,4 +1,6 @@
 jupyterlab
+jupyterhub
+jupyterhub-nativeauthenticator
 pyspark==3.4.2
 pandas
 numpy

--- a/datalakehouse-api/Dockerfile
+++ b/datalakehouse-api/Dockerfile
@@ -43,6 +43,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY *.py .
 
-EXPOSE 8181
+EXPOSE 8282
 
 CMD ["sh", "-c", "python lakehouse_query_api.py"]


### PR DESCRIPTION
Two isolated bug fixes, separate commits.

---

## Commit 1 — `datalakehouse-api/Dockerfile`: correct stale EXPOSE port

`EXPOSE 8181` → `EXPOSE 8282`

The app binds on port 8282. The compose port mapping was already correct (`8282:8282`) so this is cosmetic, but aligns image metadata with reality.

Closes #21

---

## Commit 2 — `JupyterHub/`: convert single-user JupyterLab to multi-user JupyterHub

**Problem:** Despite the directory being named `JupyterHub`, the container was a single-user JupyterLab with no authentication and no user isolation. The `jupyterhub_config.py` was fully written but completely ignored by the Dockerfile.

**Changes:**

`requirements.txt` — add:
```
jupyterhub
jupyterhub-nativeauthenticator
```

`Dockerfile` — replace final block:
- Create `/data` (JupyterHub sqlite DB + cookie secret), `/etc/jupyterhub`, `/srv/notebooks`
- `COPY jupyterhub_config.py /etc/jupyterhub/jupyterhub_config.py`
- `COPY notebooks/ /srv/notebooks/`
- `EXPOSE 8000` (was 8888)
- `CMD ["jupyterhub", "--config=/etc/jupyterhub/jupyterhub_config.py"]` (was `jupyter lab ...`)

**Result:**
- JupyterHub login screen on port 8000
- Each user gets an isolated JupyterLab process and home directory
- Shared dashboards mounted read-only at `/srv/notebooks/`
- All Spark/S3A/Hudi env vars already passed through to user kernels via existing `jupyterhub_config.py` `Spawner.environment`
- NativeAuthenticator: open signup, admin approval, first admin set via `JUPYTERHUB_ADMIN` env var

**Compose change required (in full-stack-docker-tazama):** port mapping `8888:8888` → `8000:8000`, add `/data` volume for state persistence, add `JUPYTERHUB_ADMIN` to `env/jupyterlab.env`.

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JupyterHub multi-user server with native authentication support now available for collaborative notebook environments.

* **Updates**
  * JupyterHub accessible on port 8000 (changed from port 8888).
  * Data lakehouse API endpoint now accessible on port 8282 (changed from port 8181).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->