### PR TITLE
fix: install configurable-http-proxy; add CI continue-on-error for attestation

### DIFF
--- a/.github/workflows/dockerhub-image-build-multi-rc.yml
+++ b/.github/workflows/dockerhub-image-build-multi-rc.yml
@@ -63,6 +63,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
+        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-automation-orchestrator
@@ -118,6 +119,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
+        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-datalakehouse-api
@@ -173,6 +175,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
+        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-jupyterlab
@@ -230,6 +233,7 @@ jobs:
             GH_TOKEN=${{ secrets.GH_TOKEN }}
 
       - name: Generate artifact attestation
+        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-unstructured-pipeline
@@ -285,6 +289,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
+        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-nifi

--- a/JupyterHub/Dockerfile
+++ b/JupyterHub/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update && apt-get install -y \
     procps \
     ca-certificates \
     tar \
-    && rm -rf /var/lib/apt/lists/*
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g configurable-http-proxy
 
 # Java 11 (Temurin)
 ARG TEMURIN_11_TAG=jdk-11.0.30+7


### PR DESCRIPTION
## Summary

Two fixes on top of the already-merged #23 (JupyterHub conversion):

### Fix: missing `configurable-http-proxy` in JupyterHub image

JupyterHub requires `configurable-http-proxy` (a Node.js package) to run its built-in HTTP proxy. The package was not installed in the image, causing `biar-jupyterhub` to crash-loop immediately after deployment with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'configurable-http-proxy'
```

Adds `nodejs` and `npm` to the `apt-get install` step in `JupyterHub/Dockerfile`, then installs the proxy globally with `npm install -g configurable-http-proxy`.

### CI: `continue-on-error` on artifact attestation steps

Attestation steps in `dockerhub-image-build-multi-rc.yml` were blocking the entire publish workflow on transient failures. Adds `continue-on-error: true` to all five `Generate artifact attestation` steps so a failed attestation does not prevent images from being published to DockerHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI/CD pipeline stability to gracefully handle attestation generation failures without interrupting image builds.
  * Updated container image with Node.js runtime and HTTP proxy utilities for expanded functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->