### PR TITLE
fix(jupyterhub): set allow_all=True so NativeAuthenticator is_authorized is the sole gate

### DIFF
--- a/JupyterHub/jupyterhub_config.py
+++ b/JupyterHub/jupyterhub_config.py
@@ -30,9 +30,12 @@ c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"
 admin = os.environ.get("JUPYTERHUB_ADMIN", "admin")
 c.Authenticator.admin_users = {admin}
 
-# Users must be authorized by an admin before they can log in
+# New signups require admin approval before they can log in.
+# NativeAuthenticator's own is_authorized flag (set to 0 on signup) is the
+# security gate — allow_all=True just prevents JupyterHub from adding a second,
+# conflicting block on top of NativeAuthenticator's own authorization check.
 c.NativeAuthenticator.open_signup = False
-c.Authenticator.allow_all = False
+c.Authenticator.allow_all = True
 
 # --- Networking ---
 c.JupyterHub.ip = "0.0.0.0"


### PR DESCRIPTION
## Problem

With `allow_all = False` and no `allowed_users` set, JupyterHub's base Authenticator blocks **everyone** — including admin users — even after NativeAuthenticator successfully validates the password and `is_authorized = 1`.

Log evidence:
```
[W] No allow config found, it's possible that nobody can login to your Hub!
[W] User 'admin' not allowed.
[W] Failed login for admin
```

## Fix

Set `c.Authenticator.allow_all = True`.

NativeAuthenticator's own `is_authorized` flag (set to `0` on signup, flipped to `1` by an admin) is the real security gate:
- `open_signup = False` → new signups start with `is_authorized = 0` (cannot log in until approved)
- `allow_all = True` → JupyterHub doesn't add a second, conflicting block on top of NativeAuthenticator's own authorization check

## Testing
- Unauthorized signup cannot log in (is_authorized = 0)
- Admin-approved users can log in (is_authorized = 1)
- Admin user can access `/hub/admin`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication authorization configuration to streamline how authorization checks are processed between JupyterHub and NativeAuthenticator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->