### PR TITLE
fix(jupyterhub): remove unexpanded {username} from Spawner.args

### DIFF
--- a/JupyterHub/jupyterhub_config.py
+++ b/JupyterHub/jupyterhub_config.py
@@ -8,7 +8,7 @@ c.JupyterHub.spawner_class = "simple"
 # Each user gets an isolated workspace under /srv/notebooks/{username}.
 # Shared dashboards are symlinked read-only from /srv/shared_notebooks.
 c.Spawner.notebook_dir = "/srv/notebooks/{username}"
-c.Spawner.args = ["--ServerApp.root_dir=/srv/notebooks/{username}", "--allow-root"]
+c.Spawner.args = ["--allow-root"]
 c.Spawner.default_url = "/lab"
 
 # Spark/Java initialization can take >30s; give the notebook server more time.


### PR DESCRIPTION
## Problem

JupyterHub expands `{username}` in `Spawner.notebook_dir` but **not** in `Spawner.args`. The config had:

```python
c.Spawner.args = ["--ServerApp.root_dir=/srv/notebooks/{username}", "--allow-root"]
```

This caused every spawn to fail immediately with:

```
Bad config encountered during initialization: No such directory: '/srv/notebooks/{username}'
```

The single-user server received the literal string `--ServerApp.root_dir=/srv/notebooks/{username}` and tried to use `/srv/notebooks/{username}` (unexpanded) as the root directory, which does not exist.

## Fix

Removed `--ServerApp.root_dir` from `Spawner.args`. `Spawner.notebook_dir = "/srv/notebooks/{username}"` is the correct mechanism - JupyterHub expands the template and passes the result to the single-user server itself.

`--allow-root` is retained in `Spawner.args` (required because SimpleLocalProcessSpawner runs as root).

## Verified against

Live container log (`biar-jupyterhub`) showing the timeout and bad-directory error after redeploy on 2026-04-24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JupyterHub notebook server spawner configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->