### PR TITLE
fix: disable hive style partitioning in hudi options

### DIFF
--- a/automation-orchestrator/lakehouse_automation_pipeline.py
+++ b/automation-orchestrator/lakehouse_automation_pipeline.py
@@ -115,7 +115,7 @@ def hudi_opts(table_name: str, record_key: str, precombine: str, partition: str 
         opts.update({
             "hoodie.datasource.write.partitionpath.field": partition,
             "hoodie.datasource.write.keygenerator.class": "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
-            "hoodie.datasource.write.hive_style_partitioning": "true",
+            "hoodie.datasource.write.hive_style_partitioning": "false",
         })
     else:
         opts["hoodie.datasource.write.keygenerator.class"] = "org.apache.hudi.keygen.NonpartitionedKeyGenerator"


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Hudi write operations were failing with a config conflict error because the job was attempting to write with hive_style_partitioning = true, while the existing Hudi tables were originally created with hive_style_partitioning = false.
Since Hudi enforces immutability for certain table configurations, this mismatch caused the write to fail.

## Why are we doing this?
To process the pacs008 tables for the existing Hudi Tables.

## How was it tested?
- [ ] Locally
- [ x ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Hudi write configuration to disable Hive-style partitioning when processing partitioned data while maintaining existing behavior for non-partitioned data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->