### PR TITLE
fix: enable source_file_path and record_hash in create_alert_navigator

### DIFF
--- a/automation-orchestrator/lakehouse_automation_pipeline.py
+++ b/automation-orchestrator/lakehouse_automation_pipeline.py
@@ -3017,8 +3017,8 @@ def create_alert_navigator_views(spark, WAREHOUSE_ROOT: str) -> str:
             F.col("alert_data_obj.evaluationID").alias("evaluation_id"),
             F.col("alert_data_obj.status").alias("alert_status"),
             F.col("created_at_ts").cast("timestamp").alias("ingested_at_ts"),
-            # F.col("source_file_path").alias("source_file_path"),
-            # F.col("record_hash").alias("record_hash"),
+            F.col("source_file_path").alias("source_file_path"),
+            F.col("record_hash").alias("record_hash"),
         )
     )
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Brought back `source_file_path` and `record_hash` to the selected alert output fields.

## Why are we doing this?
To create alert_navigator views and preserve source-level traceability for each ingested alert record.

## How was it tested?
- [ x ] Locally
- [ x ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The alerts navigator now displays two additional data fields, providing enhanced visibility and improved tracking capabilities for alert information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->