### PR TITLE
fix: enable hive style partitioning in Hudi options and update record 

### DIFF
--- a/automation-orchestrator/lakehouse_automation_pipeline.py
+++ b/automation-orchestrator/lakehouse_automation_pipeline.py
@@ -115,7 +115,7 @@ def hudi_opts(table_name: str, record_key: str, precombine: str, partition: str 
         opts.update({
             "hoodie.datasource.write.partitionpath.field": partition,
             "hoodie.datasource.write.keygenerator.class": "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
-            "hoodie.datasource.write.hive_style_partitioning": "true",
+            "hoodie.datasource.write.hive_style_partitioning": "false",
         })
     else:
         opts["hoodie.datasource.write.keygenerator.class"] = "org.apache.hudi.keygen.NonpartitionedKeyGenerator"

--- a/automation-orchestrator/lakehouse_automation_pipeline.py
+++ b/automation-orchestrator/lakehouse_automation_pipeline.py
@@ -115,7 +115,7 @@ def hudi_opts(table_name: str, record_key: str, precombine: str, partition: str 
         opts.update({
             "hoodie.datasource.write.partitionpath.field": partition,
             "hoodie.datasource.write.keygenerator.class": "org.apache.hudi.keygen.NonpartitionedKeyGenerator",
-            "hoodie.datasource.write.hive_style_partitioning": "false",
+            "hoodie.datasource.write.hive_style_partitioning": "true",
         })
     else:
         opts["hoodie.datasource.write.keygenerator.class"] = "org.apache.hudi.keygen.NonpartitionedKeyGenerator"
@@ -3018,7 +3018,7 @@ def create_alert_navigator_views(spark, WAREHOUSE_ROOT: str) -> str:
             F.col("alert_data_obj.status").alias("alert_status"),
             F.col("created_at_ts").cast("timestamp").alias("ingested_at_ts"),
             F.col("source_file_path").alias("source_file_path"),
-            F.col("record_hash").alias("record_hash"),
+            F.lit("").alias("record_hash"),
         )
     )
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Used F.lit instead of F.col to satisfy the avro schema of Hudi for Alert Navigator

## Why are we doing this?
Hudi write to fail with NullPointerException: null value for (non-nullable) string at vw_alerts_nav_header_record.source_file_path — because the existing Hudi table schema still required those columns, and schema reconciliation filled them with nulls.

## How was it tested?
- [ ] Locally
- [ x ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data write handling for partitioned tables to optimize data organization.
  * Alert Navigator header view no longer propagates source record hash — the header's record_hash field is now emitted as an empty string to prevent unintended propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->