### PR TITLE
fix: ETL pipeline primary key references

### DIFF
--- a/automation-orchestrator/Table_ETLs/Pacs002ETL.py
+++ b/automation-orchestrator/Table_ETLs/Pacs002ETL.py
@@ -155,7 +155,8 @@ class Pacs002ETL(BaseETL):
         self.write_hudi(
             silver,
             self.silver_path,
-            self.hudi_opts("silver_pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date_silver",),
+            self.hudi_opts("silver_pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date",
+                payload_class="org.apache.hudi.common.model.OverwriteWithLatestAvroPayload"),
         )
         print(f"[Pacs002ETL] Silver written → {self.silver_path}")
         return self.silver_path
@@ -212,7 +213,8 @@ class Pacs002ETL(BaseETL):
         self.write_hudi(
             gold,
             self.gold_path,
-            self.hudi_opts("pacs002", "end_to_end_id", "ingested_at_ts"),
+            self.hudi_opts("pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date",
+                payload_class="org.apache.hudi.common.model.OverwriteWithLatestAvroPayload"),
         )
         print(f"[Pacs002ETL] Gold written → {self.gold_path}")
         return self.gold_path

--- a/automation-orchestrator/Table_ETLs/Pacs002ETL.py
+++ b/automation-orchestrator/Table_ETLs/Pacs002ETL.py
@@ -155,7 +155,7 @@ class Pacs002ETL(BaseETL):
         self.write_hudi(
             silver,
             self.silver_path,
-            self.hudi_opts("silver_pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date",
+            self.hudi_opts("silver_pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date_silver",
                 payload_class="org.apache.hudi.common.model.OverwriteWithLatestAvroPayload"),
         )
         print(f"[Pacs002ETL] Silver written → {self.silver_path}")

--- a/automation-orchestrator/Table_ETLs/Pacs002ETL.py
+++ b/automation-orchestrator/Table_ETLs/Pacs002ETL.py
@@ -76,7 +76,8 @@ class Pacs002ETL(BaseETL):
         self.write_hudi(
             bronze,
             self.bronze_path,
-            self.hudi_opts("bronze_pacs002", "end_to_end_id", "ingested_at_ts"),
+            self.hudi_opts("bronze_pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date",
+                payload_class="org.apache.hudi.common.model.OverwriteWithLatestAvroPayload"),
         )
         print(f"[Pacs002ETL] Bronze written → {self.bronze_path}")
         return self.bronze_path
@@ -154,7 +155,7 @@ class Pacs002ETL(BaseETL):
         self.write_hudi(
             silver,
             self.silver_path,
-            self.hudi_opts("silver_pacs002", "end_to_end_id", "ingested_at_ts"),
+            self.hudi_opts("silver_pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date_silver",),
         )
         print(f"[Pacs002ETL] Silver written → {self.silver_path}")
         return self.silver_path

--- a/automation-orchestrator/Table_ETLs/RulesETL.py
+++ b/automation-orchestrator/Table_ETLs/RulesETL.py
@@ -83,8 +83,8 @@ class RulesETL(BaseETL):
             .withColumn("band_count",          F.coalesce(F.size(F.col("config_obj.bands")), F.lit(0)).cast("int"))
             .withColumn("exit_condition_count", F.coalesce(F.size(F.col("config_obj.exitConditions")), F.lit(0)).cast("int"))
             #.withColumn("evaluation_interval_time_ms", F.col("config_obj.parameters").getField("evaluationIntervalTime").cast("long"))
-            #.withColumn("tolerance",           F.col("config_obj.parameters.tolerance").cast("double"))
-            .withColumn("commission",          F.col("config_obj.parameters.commission").cast("double"))
+            .withColumn("tolerance",           F.col("config_obj.parameters.tolerance").cast("double"))
+            .withColumn("commissionRate",          F.col("config_obj.parameters.commissionRate").cast("double"))
             .withColumn("max_query_range_ms",  F.col("config_obj.parameters.maxQueryRange").cast("long"))
             .withColumn("config_json",         F.to_json(F.col("rule_obj.config")))
             .withColumn("parameters_json",     F.to_json(F.col("config_obj.parameters")))
@@ -102,7 +102,7 @@ class RulesETL(BaseETL):
         silver = s.withColumn("rn", F.row_number().over(w)).filter("rn = 1").drop("rn")
         silver = silver.select(
             "pk", "tenant_id", "rule_id", "rule_cfg", "rule_desc",
-            "band_count", "exit_condition_count", "evaluation_interval_time_ms", "commission", "max_query_range_ms",
+            "band_count", "exit_condition_count", "evaluation_interval_time_ms", "commissionRate", "max_query_range_ms",
             "configuration_json", "configuration_parsed_json", "config_json",
             "parameters_json", "bands_json", "exit_conditions_json",
             "created_at_ts", "source_file_path", "record_hash", "_row_payload_json",
@@ -133,9 +133,9 @@ class RulesETL(BaseETL):
             .withColumn("rule_desc",                   F.col("rule_obj.desc").cast("string"))
             .withColumn("band_count",                  F.coalesce(F.size("bands_arr"), F.lit(0)).cast("int"))
             .withColumn("exit_condition_count",        F.coalesce(F.size("exits_arr"), F.lit(0)).cast("int"))
-            .withColumn("evaluation_interval_time_ms", F.col("params.evaluationIntervalTime").cast("long"))
-            #.withColumn("tolerance",                   F.col("params.tolerance").cast("double"))
-            .withColumn("commission",                  F.col("params.commission").cast("double"))
+            #.withColumn("evaluation_interval_time_ms", F.col("params.evaluationIntervalTime").cast("long"))
+            .withColumn("tolerance",                   F.col("params.tolerance").cast("double"))
+            .withColumn("commissionRate",                  F.col("params.commissionRate").cast("double"))
             .withColumn("max_query_range_ms",          F.col("params.maxQueryRange").cast("long"))
             .withColumn("tenant_id_norm",              F.upper(F.col("tenant_id")))
             .withColumn("rule_id_norm",                F.upper(F.col("rule_id")))
@@ -148,7 +148,7 @@ class RulesETL(BaseETL):
             F.col("pk"), F.col("tenant_id"), F.col("tenant_id_norm"),
             F.col("rule_id"), F.col("rule_id_norm"), F.col("rule_cfg"), F.col("rule_cfg_norm"),
             F.col("rule_desc"), F.col("band_count"), F.col("exit_condition_count"),
-            #F.col("evaluation_interval_time_ms"), F.col("tolerance"), F.col("commission"),
+            F.col("evaluation_interval_time_ms"), F.col("tolerance"), F.col("commissionRate"),
             F.col("max_query_range_ms"), F.col("source_file_path"), F.col("record_hash"),
             F.col("created_at_ts"), F.col("ingested_at_ts"), F.col("as_of_date"),
         ]

--- a/automation-orchestrator/Table_ETLs/RulesETL.py
+++ b/automation-orchestrator/Table_ETLs/RulesETL.py
@@ -1,224 +1,249 @@
 from __future__ import annotations
- 
+
 from pyspark.sql import functions as F
-from pyspark.sql import types as T
 from pyspark.sql.window import Window
- 
+
 from .BaseETL import BaseETL
 
 
-_MAX_BANDS = 20
-_MAX_EXITS = 20
- 
 class RulesETL(BaseETL):
-    """Full Bronze → Silver → Gold pipeline for Rule configurations."""
- 
+    """Full Bronze → Silver → Gold pipeline for Rule data."""
+
     @property
     def bronze_path(self) -> str:
-        return f"{self.warehouse_root}/bronze/rules"
- 
+        return f"{self.warehouse_root}/bronze/rule"
+
     @property
     def silver_path(self) -> str:
-        return f"{self.warehouse_root}/silver/rules"
- 
+        return f"{self.warehouse_root}/silver/rule"
+
     @property
     def gold_path(self) -> str:
-        return f"{self.warehouse_root}/gold/rules"
- 
+        return f"{self.warehouse_root}/gold/rule"
+
+    # ------------------------------------------------------------------
+    # BRONZE
+    # ------------------------------------------------------------------
+
     def bronze(self, source_path: str) -> str:
-        rule_df = self.spark.read.json(source_path)
- 
+        raw = self.spark.read.json(source_path)
+
         bronze = (
-            rule_df
-            .withColumnRenamed("tenantid", "tenant_id")
+            raw
             .withColumnRenamed("ruleid",   "rule_id")
             .withColumnRenamed("rulecfg",  "rule_cfg")
-        )
- 
-        # Normalize configuration – could be struct or string
-        conf_dtype = dict(bronze.dtypes).get("configuration", "")
-        if conf_dtype.startswith("string"):
-            bronze = bronze.withColumn("configuration_json", F.col("configuration").cast("string"))
-        else:
-            bronze = bronze.withColumn(
-                "configuration_json",
-                F.when(F.col("configuration").isNull(), F.lit(None).cast("string"))
-                 .otherwise(F.to_json(F.col("configuration"))),
-            )
- 
-        bronze = (
-            bronze
-            .select("tenant_id", "rule_id", "rule_cfg", "configuration_json")
-            .withColumn("created_at_ts",    F.current_timestamp())
-            .withColumn("source_file_path", F.lit("api_or_file_ingestion"))
+            .withColumnRenamed("tenantid", "tenant_id")
+            .withColumn("configuration",    F.col("configuration").cast("string"))
+            .withColumn("credttm",          F.col("credttm").cast("string"))
+            .withColumn("upddttm",          F.col("upddttm").cast("string"))
+            .withColumn("ingested_at_ts",   F.current_timestamp())
+            .withColumn("source_file_path", F.input_file_name())
             .withColumn(
                 "record_hash",
-                F.sha2(F.concat_ws("||",
-                    F.coalesce(F.col("tenant_id").cast("string"),          F.lit("")),
-                    F.coalesce(F.col("rule_id").cast("string"),            F.lit("")),
-                    F.coalesce(F.col("rule_cfg").cast("string"),           F.lit("")),
-                    F.coalesce(F.col("configuration_json").cast("string"), F.lit("")),
-                ), 256),
+                F.sha2(
+                    F.concat_ws("||",
+                        F.coalesce(F.col("rule_id"),       F.lit("")),
+                        F.coalesce(F.col("rule_cfg"),      F.lit("")),
+                        F.coalesce(F.col("tenant_id"),     F.lit("")),
+                        F.coalesce(F.col("configuration"), F.lit("")),
+                    ),
+                    256,
+                ),
             )
-            .withColumn("_row_payload_json", F.to_json(F.struct("*")))
         )
- 
-        self.write_hudi(bronze, self.bronze_path, self.hudi_opts("bronze_rules", "record_hash", "created_at_ts"))
-        print(f"[RulesETL] Bronze written → {self.bronze_path}")
+        # _row_payload_json must be added after renames are resolved so
+        # bronze.columns reflects the new names, not the raw source names.
+        bronze = bronze.withColumn(
+            "_row_payload_json",
+            F.to_json(F.struct(*[F.col(c) for c in bronze.columns])),
+        )
+
+        self.write_hudi(
+            bronze,
+            self.bronze_path,
+            self.hudi_opts("bronze_rule", "record_hash", "ingested_at_ts"),
+        )
+        print(f"[RuleETL] Bronze written → {self.bronze_path}")
         return self.bronze_path
- 
+
+    # ------------------------------------------------------------------
+    # SILVER
+    # ------------------------------------------------------------------
+
     def silver(self) -> str:
-        b = self.spark.read.format("hudi").load(self.bronze_path)
-        rule_schema = self.spark.read.json(
-            b.where(F.col("configuration_json").isNotNull()).select("configuration_json").rdd.map(lambda r: r[0])
-        ).schema
- 
-        s = (
+        bronze_in = self.spark.read.format("hudi").load(self.bronze_path)
+
+        config_schema = self.infer_json_schema(bronze_in, "configuration")
+        b = bronze_in.withColumn("cfg_obj", F.from_json("configuration", config_schema))
+
+        # --- top-level config fields ---
+        rule_id_in_json  = F.col("cfg_obj.id").cast("string")
+        rule_cfg_in_json = F.col("cfg_obj.cfg").cast("string")
+        rule_desc        = F.col("cfg_obj.desc").cast("string")
+        rule_tenant_id   = F.col("cfg_obj.tenantId").cast("string")
+
+        # --- timestamps: top-level columns first, embedded JSON as fallback ---
+        rule_created_ts = F.coalesce(
+            F.to_timestamp(F.col("credttm")),
+            F.to_timestamp(F.col("cfg_obj.creDtTm")),
+        )
+        rule_updated_ts = F.coalesce(
+            F.to_timestamp(F.col("upddttm")),
+            F.to_timestamp(F.col("cfg_obj.updDtTm")),
+        )
+
+        # --- parameters ---
+        tolerance       = F.col("cfg_obj.config.parameters.tolerance").cast("double")
+        max_query_range = F.col("cfg_obj.config.parameters.maxQueryRange").cast("long")
+
+        # --- counts ---
+        band_count           = F.coalesce(F.size(F.col("cfg_obj.config.bands")),          F.lit(0)).cast("int")
+        exit_condition_count = F.coalesce(F.size(F.col("cfg_obj.config.exitConditions")), F.lit(0)).cast("int")
+
+        # --- cases block (present in rules like country-case, taxcase) ---
+        has_cases_block = (
+            F.when(F.col("cfg_obj.config.cases").isNotNull(), F.lit(1))
+             .otherwise(F.lit(0))
+             .cast("int")
+        )
+
+        # --- serialise sub-structures as JSON strings ---
+        bands_json           = F.to_json(F.col("cfg_obj.config.bands"))
+        exit_conditions_json = F.to_json(F.col("cfg_obj.config.exitConditions"))
+        parameters_json      = F.to_json(F.col("cfg_obj.config.parameters"))
+        cases_json           = F.to_json(F.col("cfg_obj.config.cases"))
+
+        # --- composite PK: tenant_id + rule_id + rule_cfg ---
+        pk = F.sha2(
+            F.concat_ws("||",
+                F.coalesce(F.col("tenant_id"), F.lit("")),
+                F.coalesce(F.col("rule_id"),   F.lit("")),
+                F.coalesce(F.col("rule_cfg"),  F.lit("")),
+            ),
+            256,
+        )
+
+        silver = (
             b
-            .withColumn("rule_obj",            F.from_json("configuration_json", rule_schema))
-            .withColumn("config_obj",          F.col("rule_obj.config"))
-            .withColumn("rule_id_in_json",     F.col("rule_obj.id").cast("string"))
-            .withColumn("rule_cfg_in_json",    F.col("rule_obj.cfg").cast("string"))
-            .withColumn("rule_desc",           F.col("rule_obj.desc").cast("string"))
-            .withColumn("band_count",          F.coalesce(F.size(F.col("config_obj.bands")), F.lit(0)).cast("int"))
-            .withColumn("exit_condition_count", F.coalesce(F.size(F.col("config_obj.exitConditions")), F.lit(0)).cast("int"))
-            #.withColumn("evaluation_interval_time_ms", F.col("config_obj.parameters").getField("evaluationIntervalTime").cast("long"))
-            .withColumn("tolerance",           F.col("config_obj.parameters.tolerance").cast("double"))
-            .withColumn("commissionRate",          F.col("config_obj.parameters.commissionRate").cast("double"))
-            .withColumn("max_query_range_ms",  F.col("config_obj.parameters.maxQueryRange").cast("long"))
-            .withColumn("config_json",         F.to_json(F.col("rule_obj.config")))
-            .withColumn("parameters_json",     F.to_json(F.col("config_obj.parameters")))
-            .withColumn("bands_json",          F.to_json(F.col("config_obj.bands")))
-            .withColumn("exit_conditions_json", F.to_json(F.col("config_obj.exitConditions")))
-            .withColumn("configuration_parsed_json", F.to_json(F.col("rule_obj")))
-            .withColumn("pk", F.sha2(F.concat_ws("||",
-                F.coalesce(F.col("tenant_id").cast("string"), F.lit("")),
-                F.coalesce(F.col("rule_id").cast("string"),   F.lit("")),
-                F.coalesce(F.col("rule_cfg").cast("string"),  F.lit("")),
-            ), 256))
+            .withColumn("rule_id_in_json",      rule_id_in_json)
+            .withColumn("rule_cfg_in_json",      rule_cfg_in_json)
+            .withColumn("rule_desc",             rule_desc)
+            .withColumn("rule_tenant_id",        rule_tenant_id)
+            .withColumn("rule_created_ts",       rule_created_ts)
+            .withColumn("rule_updated_ts",       rule_updated_ts)
+            .withColumn("rule_created_date",     F.to_date(rule_created_ts))
+            .withColumn("rule_updated_date",     F.to_date(rule_updated_ts))
+            .withColumn("tolerance",             tolerance)
+            .withColumn("max_query_range_ms",    max_query_range)
+            .withColumn("band_count",            band_count)
+            .withColumn("exit_condition_count",  exit_condition_count)
+            .withColumn("has_cases_block",       has_cases_block)
+            .withColumn("bands_json",            bands_json)
+            .withColumn("exit_conditions_json",  exit_conditions_json)
+            .withColumn("parameters_json",       parameters_json)
+            .withColumn("cases_json",            cases_json)
+            .withColumn("pk",                    pk)
+            .withColumn("ingested_at_ts",        F.coalesce(F.col("ingested_at_ts"), F.current_timestamp()))
+            # Drop bronze-only and intermediate columns
+            .drop("_row_payload_json", "cfg_obj", "credttm", "upddttm")
         )
- 
-        w = Window.partitionBy("pk").orderBy(F.col("created_at_ts").desc())
-        silver = s.withColumn("rn", F.row_number().over(w)).filter("rn = 1").drop("rn")
-        silver = silver.select(
-            "pk", "tenant_id", "rule_id", "rule_cfg", "rule_desc",
-            "band_count", "exit_condition_count", "evaluation_interval_time_ms", "commissionRate", "max_query_range_ms",
-            "configuration_json", "configuration_parsed_json", "config_json",
-            "parameters_json", "bands_json", "exit_conditions_json",
-            "created_at_ts", "source_file_path", "record_hash", "_row_payload_json",
-        )
- 
-        self.write_hudi(silver, self.silver_path, self.hudi_opts("silver_rules", "pk", "created_at_ts"))
-        print(f"[RulesETL] Silver written → {self.silver_path}")
-        return self.silver_path
- 
-    def gold(self) -> str:
-        s = self.spark.read.format("hudi").load(self.silver_path)
-        rule_schema = self.spark.read.json(
-            s.where(F.col("configuration_json").isNotNull()).select("configuration_json").rdd.map(lambda r: r[0])
-        ).schema
- 
-        g = (
-            s
-            .withColumn("rule_obj",    F.from_json("configuration_json", rule_schema))
-            .withColumn("config_obj",  F.col("rule_obj.config"))
-            .withColumn("bands_arr",   F.col("config_obj.bands"))
-            .withColumn("exits_arr",   F.col("config_obj.exitConditions"))
-            .withColumn("params",      F.col("config_obj.parameters"))
-            .withColumn("pk", F.sha2(F.concat_ws("||",
-                F.coalesce(F.col("tenant_id").cast("string"), F.lit("")),
-                F.coalesce(F.col("rule_id").cast("string"),   F.lit("")),
-                F.coalesce(F.col("rule_cfg").cast("string"),  F.lit("")),
-            ), 256))
-            .withColumn("rule_desc",                   F.col("rule_obj.desc").cast("string"))
-            .withColumn("band_count",                  F.coalesce(F.size("bands_arr"), F.lit(0)).cast("int"))
-            .withColumn("exit_condition_count",        F.coalesce(F.size("exits_arr"), F.lit(0)).cast("int"))
-            #.withColumn("evaluation_interval_time_ms", F.col("params.evaluationIntervalTime").cast("long"))
-            .withColumn("tolerance",                   F.col("params.tolerance").cast("double"))
-            .withColumn("commissionRate",                  F.col("params.commissionRate").cast("double"))
-            .withColumn("max_query_range_ms",          F.col("params.maxQueryRange").cast("long"))
-            .withColumn("tenant_id_norm",              F.upper(F.col("tenant_id")))
-            .withColumn("rule_id_norm",                F.upper(F.col("rule_id")))
-            .withColumn("rule_cfg_norm",               F.col("rule_cfg").cast("string"))
-            .withColumn("ingested_at_ts",              F.current_timestamp())
-            .withColumn("as_of_date",                  F.to_date("ingested_at_ts"))
-        )
- 
-        base_cols = [
-            F.col("pk"), F.col("tenant_id"), F.col("tenant_id_norm"),
-            F.col("rule_id"), F.col("rule_id_norm"), F.col("rule_cfg"), F.col("rule_cfg_norm"),
-            F.col("rule_desc"), F.col("band_count"), F.col("exit_condition_count"),
-            F.col("evaluation_interval_time_ms"), F.col("tolerance"), F.col("commissionRate"),
-            F.col("max_query_range_ms"), F.col("source_file_path"), F.col("record_hash"),
-            F.col("created_at_ts"), F.col("ingested_at_ts"), F.col("as_of_date"),
-        ]
- 
-        band_cols = []
-        for i in range(1, _MAX_BANDS + 1):
-            p = f"band_{i:02d}"
-            band_cols += [
-                F.element_at(F.col("bands_arr"), i).getField("reason").cast("string").alias(f"{p}_reason"),
-                F.element_at(F.col("bands_arr"), i).getField("subRuleRef").cast("string").alias(f"{p}_sub_rule_ref"),
-                F.element_at(F.col("bands_arr"), i).getField("lowerLimit").cast("double").alias(f"{p}_lower_limit"),
-                F.element_at(F.col("bands_arr"), i).getField("upperLimit").cast("double").alias(f"{p}_upper_limit"),
-            ]
- 
-        exit_cols = []
-        for i in range(1, _MAX_EXITS + 1):
-            p = f"exit_{i:02d}"
-            exit_cols += [
-                F.element_at(F.col("exits_arr"), i).getField("reason").cast("string").alias(f"{p}_reason"),
-                F.element_at(F.col("exits_arr"), i).getField("subRuleRef").cast("string").alias(f"{p}_sub_rule_ref"),
-            ]
- 
-        # ------------------------------------------------------------------
-        # Overflow guards: JSON-serialize anything beyond the fixed-width projection
-        # so band_count / exit_condition_count remain truthful and data is not lost.
-        # ------------------------------------------------------------------
-        bands_overflow = F.when(
-            F.size(F.col("bands_arr")) > _MAX_BANDS,
-            F.to_json(
-                F.slice(
-                    F.col("bands_arr"),
-                    _MAX_BANDS + 1,
-                    F.size(F.col("bands_arr")) - _MAX_BANDS,
-                )
-            ),
-        ).otherwise(F.lit(None).cast("string")).alias("bands_overflow_json")
- 
-        exits_overflow = F.when(
-            F.size(F.col("exits_arr")) > _MAX_EXITS,
-            F.to_json(
-                F.slice(
-                    F.col("exits_arr"),
-                    _MAX_EXITS + 1,
-                    F.size(F.col("exits_arr")) - _MAX_EXITS,
-                )
-            ),
-        ).otherwise(F.lit(None).cast("string")).alias("exits_overflow_json")
- 
-        gold_rules = g.select(*(base_cols + band_cols + exit_cols + [bands_overflow, exits_overflow]))
- 
-        bad = [c for c, t in gold_rules.dtypes if t.startswith(("array", "struct"))]
-        if bad:
-            raise RuntimeError(f"[RulesETL] Gold has non-scalar columns: {bad}")
- 
+
+        # Dedup — keep latest per pk
         w = Window.partitionBy("pk").orderBy(F.col("ingested_at_ts").desc())
-        gold_rules = gold_rules.withColumn("rn", F.row_number().over(w)).filter("rn = 1").drop("rn")
- 
+        silver = silver.withColumn("rn", F.row_number().over(w)).filter("rn = 1").drop("rn")
+
+        self.write_hudi(
+            silver,
+            self.silver_path,
+            self.hudi_opts("silver_rule", "pk", "ingested_at_ts"),
+        )
+        print(f"[RuleETL] Silver written → {self.silver_path}")
+        return self.silver_path
+
+    # ------------------------------------------------------------------
+    # GOLD
+    # ------------------------------------------------------------------
+
+    def gold(self) -> str:
+        silver_in = self.spark.read.format("hudi").load(self.silver_path)
+
+        gold = (
+            silver_in
+            .withColumn("tenant_id_norm", F.upper(F.col("tenant_id")))
+            .withColumn("rule_id_norm",   F.upper(F.col("rule_id")))
+            .withColumn(
+                "has_tolerance",
+                F.when(F.col("tolerance").isNotNull(), F.lit(1))
+                 .otherwise(F.lit(0))
+                 .cast("int"),
+            )
+            .withColumn(
+                "has_max_query_range",
+                F.when(F.col("max_query_range_ms").isNotNull(), F.lit(1))
+                 .otherwise(F.lit(0))
+                 .cast("int"),
+            )
+            .withColumn(
+                "rule_type",
+                F.when(F.col("has_cases_block") == 1, F.lit("CASE"))
+                 .when(F.col("band_count") > 0,       F.lit("BAND"))
+                 .otherwise(F.lit("OTHER"))
+                 .cast("string"),
+            )
+            .select(
+                F.col("pk").cast("string").alias("pk"),
+                F.col("tenant_id").cast("string").alias("tenant_id"),
+                F.col("tenant_id_norm").cast("string").alias("tenant_id_norm"),
+                F.col("rule_id").cast("string").alias("rule_id"),
+                F.col("rule_id_norm").cast("string").alias("rule_id_norm"),
+                F.col("rule_cfg").cast("string").alias("rule_cfg"),
+                F.col("rule_id_in_json").cast("string").alias("rule_id_in_json"),
+                F.col("rule_cfg_in_json").cast("string").alias("rule_cfg_in_json"),
+                F.col("rule_desc").cast("string").alias("rule_desc"),
+                F.col("rule_tenant_id").cast("string").alias("rule_tenant_id"),
+                F.col("rule_type").cast("string").alias("rule_type"),
+                F.col("rule_created_ts").cast("timestamp").alias("rule_created_ts"),
+                F.col("rule_updated_ts").cast("timestamp").alias("rule_updated_ts"),
+                F.col("rule_created_date").cast("date").alias("rule_created_date"),
+                F.col("rule_updated_date").cast("date").alias("rule_updated_date"),
+                F.col("band_count").cast("int").alias("band_count"),
+                F.col("exit_condition_count").cast("int").alias("exit_condition_count"),
+                F.col("has_cases_block").cast("int").alias("has_cases_block"),
+                F.col("has_tolerance").cast("int").alias("has_tolerance"),
+                F.col("has_max_query_range").cast("int").alias("has_max_query_range"),
+                F.col("tolerance").cast("double").alias("tolerance"),
+                F.col("max_query_range_ms").cast("long").alias("max_query_range_ms"),
+                F.col("bands_json").cast("string").alias("bands_json"),
+                F.col("exit_conditions_json").cast("string").alias("exit_conditions_json"),
+                F.col("parameters_json").cast("string").alias("parameters_json"),
+                F.col("cases_json").cast("string").alias("cases_json"),
+                F.col("source_file_path").cast("string").alias("source_file_path"),
+                F.col("record_hash").cast("string").alias("record_hash"),
+                F.col("ingested_at_ts").cast("timestamp").alias("ingested_at_ts"),
+            )
+        )
+
+        bad = [c for c, t in gold.dtypes if t.startswith(("array", "struct", "map"))]
+        if bad:
+            raise RuntimeError(f"[RuleETL] Gold has non-scalar columns: {bad}")
+
         gold_opts = {
-            **self.hudi_opts("rules", "pk", "ingested_at_ts", partition="as_of_date"),
-            "hoodie.datasource.write.schema.evolution.enable": "true",
-            "hoodie.datasource.write.reconcile.schema": "true",
+            **self.hudi_opts("gold_rule", "pk", "ingested_at_ts", partition="rule_created_date"),
+            "hoodie.datasource.write.payload.class":
+                "org.apache.hudi.common.model.OverwriteWithLatestAvroPayload",
         }
-        self.write_hudi(gold_rules, self.gold_path, gold_opts)
-        print(f"[RulesETL] Gold written → {self.gold_path}")
+        self.write_hudi(gold, self.gold_path, gold_opts)
+        print(f"[RuleETL] Gold written → {self.gold_path}")
         return self.gold_path
- 
+
+    # ------------------------------------------------------------------
+    # ORCHESTRATOR
+    # ------------------------------------------------------------------
+
     def run(self, source_path: str) -> str:
-        print(f"[RulesETL] Starting Bronze → Silver → Gold from {source_path}")
+        print(f"[RuleETL] Starting Bronze → Silver → Gold from {source_path}")
         self.bronze(source_path)
         self.silver()
         self.gold()
-        print("[RulesETL] ETL complete.")
+        print("[RuleETL] ETL complete.")
         return self.gold_path

--- a/automation-orchestrator/Table_ETLs/TransactionsETL.py
+++ b/automation-orchestrator/Table_ETLs/TransactionsETL.py
@@ -10,9 +10,9 @@ Transactions are derived from PACS bronze tables.  Two modes:
 Primary key
 -----------
 The record key is a composite of TxTp (message type) and EndToEndId, stored as
-a single derived column `transaction_pk`:
+a single derived column `transaction_id`:
 
-    transaction_pk = TxTp + "||" + endToEndId   (plain string concatenation)
+    transaction_id = TxTp + "||" + endToEndId   (plain string concatenation)
 
 For example: "pacs.008.001.10||2024-ABC-123-XYZ"
 
@@ -53,7 +53,7 @@ class TransactionsETL(BaseETL):
         """
         Build the plain composite primary key.
 
-        transaction_pk = TxTp + "||" + endToEndId
+        transaction_id = TxTp + "||" + endToEndId
 
         For example: "pacs.008.001.10||2024-ABC-123-XYZ"
         Both inputs are coalesced to empty string so a null never breaks
@@ -135,7 +135,7 @@ class TransactionsETL(BaseETL):
                 ),
             )
             # Composite PK: TxTp || endToEndId (plain string, no hashing)
-            .withColumn("transaction_pk", self._make_pk("tx_type", "endToEndId"))
+            .withColumn("transaction_id", self._make_pk("tx_type", "endToEndId"))
             .withColumn(
                 "record_hash",
                 F.sha2(
@@ -157,7 +157,7 @@ class TransactionsETL(BaseETL):
             bronze,
             self.bronze_path,
             # Hudi record key is the composite PK column
-            self.hudi_opts("transactions", "transaction_pk", "created_at_ts"),
+            self.hudi_opts("transactions", "transaction_id", "created_at_ts"),
         )
         print(f"[TransactionsETL] Bronze written → {self.bronze_path}")
         return self.bronze_path
@@ -274,17 +274,17 @@ class TransactionsETL(BaseETL):
                 ),
             )
             # Recompute composite PK with the now-resolved tx_type (covers null-at-bronze cases)
-            .withColumn("transaction_pk", self._make_pk("tx_type", "endToEndId"))
+            .withColumn("transaction_id", self._make_pk("tx_type", "endToEndId"))
         )
 
         # Dedup: keep latest per composite key
-        w = Window.partitionBy("transaction_pk").orderBy(F.col("created_at_ts").desc())
+        w = Window.partitionBy("transaction_id").orderBy(F.col("created_at_ts").desc())
         silver = s.withColumn("rn", F.row_number().over(w)).filter("rn = 1").drop("rn")
 
         self.write_hudi(
             silver,
             self.silver_path,
-            self.hudi_opts("silver_transactions", "transaction_pk", "created_at_ts"),
+            self.hudi_opts("silver_transactions", "transaction_id", "created_at_ts"),
         )
         print(f"[TransactionsETL] Silver written → {self.silver_path}")
         return self.silver_path
@@ -307,7 +307,7 @@ class TransactionsETL(BaseETL):
             )
             .select(
                 # Composite PK carried through to gold
-                F.col("transaction_pk").cast("string").alias("transaction_pk"),
+                F.col("transaction_id").cast("string").alias("transaction_id"),
                 F.col("endToEndId").cast("string").alias("end_to_end_id"),
                 F.col("tenantId").cast("string").alias("tenant_id"),
                 F.col("tx_type").cast("string").alias("tx_type"),
@@ -332,7 +332,7 @@ class TransactionsETL(BaseETL):
             raise RuntimeError(f"[TransactionsETL] Gold contains non-scalar cols: {bad}")
 
         gold_opts = {
-            **self.hudi_opts("transactions", "transaction_pk", "ingested_at_ts"),
+            **self.hudi_opts("transactions", "transaction_id", "ingested_at_ts"),
             "hoodie.datasource.write.payload.class": "org.apache.hudi.common.model.OverwriteWithLatestAvroPayload",
         }
         self.write_hudi(gold, self.gold_path, gold_opts)

--- a/automation-orchestrator/Table_ETLs/TypologiesETL.py
+++ b/automation-orchestrator/Table_ETLs/TypologiesETL.py
@@ -58,7 +58,6 @@ class TypologiesETL(BaseETL):
             .withColumn("typology_obj",       F.from_json(F.col("configuration_json"), typ_schema))
             .withColumn("typology_id_in_json", F.col("typology_obj.id"))
             .withColumn("typology_cfg_in_json", F.col("typology_obj.cfg"))
-            #.withColumn("typology_desc",       F.col("typology_obj").getField("desc"))
             .withColumn("typology_name",       F.col("typology_obj.typology_name"))
             .withColumn("flow_processor",      F.col("typology_obj.workflow.flowProcessor"))
             .withColumn("alert_threshold",     F.col("typology_obj.workflow.alertThreshold").cast("int"))
@@ -132,7 +131,6 @@ class TypologiesETL(BaseETL):
             F.col("typology_cfg").cast("string"),
             F.col("typology_id_in_json").cast("string"),
             F.col("typology_cfg_in_json").cast("string"),
-            #F.col("typology_desc").cast("string"),
             F.col("typology_name").cast("string"),
             F.col("flow_processor").cast("string"),
             F.col("alert_threshold").cast("int"),

--- a/automation-orchestrator/Table_ETLs/TypologiesETL.py
+++ b/automation-orchestrator/Table_ETLs/TypologiesETL.py
@@ -132,7 +132,7 @@ class TypologiesETL(BaseETL):
             F.col("typology_cfg").cast("string"),
             F.col("typology_id_in_json").cast("string"),
             F.col("typology_cfg_in_json").cast("string"),
-            F.col("typology_desc").cast("string"),
+            #F.col("typology_desc").cast("string"),
             F.col("typology_name").cast("string"),
             F.col("flow_processor").cast("string"),
             F.col("alert_threshold").cast("int"),

--- a/automation-orchestrator/Table_ETLs/alert_navigator.py
+++ b/automation-orchestrator/Table_ETLs/alert_navigator.py
@@ -106,8 +106,41 @@ class AlertNavigatorETL(BaseETL):
         )
 
         if g_tx is not None:
+            # pacs002: alert-triggering message (no amount), keep its identifiers
+            pacs002 = g_tx.alias("pacs002").filter(
+                F.col("tx_amount").isNull()
+            ).select(
+                F.trim(F.col("tx_msg_id").cast("string")).alias("tx_msg_id"),
+                F.trim(F.col("end_to_end_id").cast("string")).alias("end_to_end_id"),
+                F.trim(F.col("transaction_id").cast("string")).alias("transaction_id"),
+            )
+
+            # pacs008: settlement message with amount
+            pacs008 = g_tx.alias("pacs008").filter(
+                F.col("tx_amount").isNotNull()
+            ).select(
+                F.trim(F.col("end_to_end_id").cast("string")).alias("end_to_end_id"),
+                F.col("tx_status").cast("string").alias("tx_status"),
+                F.col("tx_amount").cast("decimal(18,2)").alias("tx_amount"),
+                F.col("tx_ccy").cast("string").alias("tx_ccy"),
+            )
+
+            # Bridge: pacs002 → pacs008 via end_to_end_id
+            g_tx_lookup = pacs002.join(
+                pacs008,
+                on="end_to_end_id",
+                how="inner",
+            ).select(
+                "tx_msg_id",
+                "end_to_end_id",
+                "transaction_id",
+                "tx_status",
+                "tx_amount",
+                "tx_ccy",
+            ).dropDuplicates(["tx_msg_id"])
+
             header = (
-                header.join(g_tx, on="tx_msg_id", how="left")
+                header.join(g_tx_lookup, on="tx_msg_id", how="left")
                 .withColumnRenamed("tx_status", "transaction_status")
                 .withColumnRenamed("tx_amount", "transaction_amount")
                 .withColumnRenamed("tx_ccy", "transaction_currency")
@@ -126,7 +159,7 @@ class AlertNavigatorETL(BaseETL):
             )
 
         return header
-
+          
     def _build_typologies(self, a: DataFrame, b_typ: DataFrame | None) -> DataFrame:
         """Build the alerts_nav_typologies view."""
         typ = (

--- a/automation-orchestrator/Table_ETLs/network_navigator_view.py
+++ b/automation-orchestrator/Table_ETLs/network_navigator_view.py
@@ -58,7 +58,7 @@ class NetworkNavigatorViewETL(BaseETL):
         rename_map = {
             "endToEndId": "end_to_end_id",
             "tenantId": "tenant_id",
-            "transaction_pk": "transaction_pk",
+            "transaction_id": "transaction_id",
         }
         for src, dst in rename_map.items():
             if src in tx.columns and dst not in tx.columns:
@@ -113,7 +113,7 @@ class NetworkNavigatorViewETL(BaseETL):
             .withColumn("dbtr_account_id", dbtr_acct)
             .withColumn("cdtr_account_id", cdtr_acct)
             .select(
-                F.col("transaction_pk").cast("long").alias("transaction_pk"),
+                F.col("transaction_id").cast("long").alias("transaction_id"),
                 F.col("end_to_end_id").cast("string").alias("end_to_end_id"),
                 F.col("tenant_id").cast("string").alias("tenant_id"),
                 F.col("tx_type").cast("string").alias("tx_type"),

--- a/automation-orchestrator/Table_ETLs/transaction_detail_view.py
+++ b/automation-orchestrator/Table_ETLs/transaction_detail_view.py
@@ -4,7 +4,7 @@ transaction_detail_view.py
 Builds the vw_transaction_detail view from bronze/transactions.
 Parses pacs.008 + pacs.002 JSON and writes a denormalized Hudi view.
 
-Carries forward the composite primary key transaction_pk
+Carries forward the composite primary key transaction_id
 (TxTp || "||" || endToEndId) from TransactionsETL as the sole primary key.
 """
 
@@ -23,7 +23,7 @@ class TransactionDetailViewETL(BaseETL):
     Reads bronze/transactions, extracts embedded PACS JSON fields,
     and writes vw_transaction_detail as a Hudi view.
 
-    Uses transaction_pk (TxTp||endToEndId) as the primary key.
+    Uses transaction_id (TxTp||endToEndId) as the primary key.
     """
 
     def __init__(self, spark, warehouse_root: str) -> None:
@@ -182,7 +182,7 @@ class TransactionDetailViewETL(BaseETL):
         has_record_hash = "record_hash" in df.columns
 
         return df.select(
-            F.col("transaction_pk").cast("string").alias("transaction_pk"),
+            F.col("transaction_id").cast("string").alias("transaction_id"),
             F.col("end_to_end_id").cast("string").alias("end_to_end_id"),
             F.col("tenant_id").cast("string").alias("tenant_id"),
             F.col("tx_tenant_id").cast("string").alias("tx_tenant_id"),
@@ -238,7 +238,7 @@ class TransactionDetailViewETL(BaseETL):
         rename_map = {
             "endToEndId": "end_to_end_id",
             "tenantId": "tenant_id",
-            "transaction_pk": "transaction_pk",
+            "transaction_id": "transaction_id",
         }
         for src, dst in rename_map.items():
             if src in tx.columns and dst not in tx.columns:
@@ -253,13 +253,13 @@ class TransactionDetailViewETL(BaseETL):
         # 5. Finalize schema
         tx_detail_view = self._finalize_schema(tx)
 
-        # 6. Write Hudi view — transaction_pk is the primary key
+        # 6. Write Hudi view — transaction_id is the primary key
         self.write_hudi(
             tx_detail_view,
             self.view_path,
             self.hudi_opts(
                 "vw_transaction_detail",
-                record_key="transaction_pk",
+                record_key="transaction_id",
                 precombine="ingested_at_ts",
             ),
         )

--- a/automation-orchestrator/Table_ETLs/transaction_history_view.py
+++ b/automation-orchestrator/Table_ETLs/transaction_history_view.py
@@ -211,21 +211,17 @@ class TransactionHistoryViewETL(BaseETL):
             .withColumn("cdtr_account_id", cdtr_acct)
         )
 
-        # Debug: log extraction coverage
-        total = base.count()
-        if total > 0:
-            stats = base.select(
-                F.sum(F.when(F.col("dbtr_id").isNotNull(), 1).otherwise(0)).alias("dbtr_id_ok"),
-                F.sum(F.when(F.col("cdtr_id").isNotNull(), 1).otherwise(0)).alias("cdtr_id_ok"),
-                F.sum(F.when(F.col("dbtr_account_id").isNotNull(), 1).otherwise(0)).alias("dbtr_acct_ok"),
-                F.sum(F.when(F.col("cdtr_account_id").isNotNull(), 1).otherwise(0)).alias("cdtr_acct_ok"),
-                F.sum(F.when(F.col("tx_amount").isNotNull(), 1).otherwise(0)).alias("amount_ok"),
-            ).collect()[0]
-            print(f"[TransactionHistoryViewETL] Extraction coverage out of {total} rows:")
-            print(f"  dbtr_id: {stats['dbtr_id_ok']}, cdtr_id: {stats['cdtr_id_ok']}")
-            print(f"  dbtr_account_id: {stats['dbtr_acct_ok']}, cdtr_account_id: {stats['cdtr_acct_ok']}")
-            print(f"  tx_amount: {stats['amount_ok']}")
-
+        stats = base.agg(
+            F.count("*").alias("total"),
+            F.sum(F.when(F.col("dbtr_id").isNotNull(), 1).otherwise(0)).alias("dbtr_id_ok"),
+            F.sum(F.when(F.col("cdtr_id").isNotNull(), 1).otherwise(0)).alias("cdtr_id_ok"),
+            F.sum(F.when(F.col("dbtr_account_id").isNotNull(), 1).otherwise(0)).alias("dbtr_acct_ok"),
+            F.sum(F.when(F.col("cdtr_account_id").isNotNull(), 1).otherwise(0)).alias("cdtr_acct_ok"),
+            F.sum(F.when(F.col("tx_amount").isNotNull(), 1).otherwise(0)).alias("amount_ok"),
+        ).collect()[0]
+        if stats["total"] > 0:
+            print(f"[TransactionHistoryViewETL] Extraction coverage out of {stats['total']} rows:")
+        
         return (
             base
             .select(

--- a/automation-orchestrator/Table_ETLs/transaction_history_view.py
+++ b/automation-orchestrator/Table_ETLs/transaction_history_view.py
@@ -393,12 +393,24 @@ class TransactionHistoryViewETL(BaseETL):
             .rowsBetween(Window.unboundedPreceding, Window.currentRow)
         )
 
+        # Only count actual payment instructions (pacs.008 / pain.001) in cumulative totals.
+        # pacs.002 is a status report for the same transaction, not a new transaction.
+        is_payment_tx = F.col("tx_type").isin(["pacs.008.001.10", "pain.001.001.11"])
+
         return (
             df.withColumn("recent_rank_desc", F.row_number().over(w_recent))
-            .withColumn("cum_tx_count", F.count(F.lit(1)).over(w_cum))
+            .withColumn(
+                "cum_tx_count",
+                F.sum(F.when(is_payment_tx, F.lit(1)).otherwise(F.lit(0))).over(w_cum),
+            )
             .withColumn(
                 "cum_tx_amount",
-                F.sum(F.coalesce(F.col("tx_amount"), F.lit(0.0))).over(w_cum),
+                F.sum(
+                    F.when(
+                        is_payment_tx,
+                        F.coalesce(F.col("tx_amount"), F.lit(0.0)),
+                    ).otherwise(F.lit(0.0))
+                ).over(w_cum),
             )
             .withColumn("row_type", F.lit("EVENT"))
             .withColumn("bucket_granularity", F.lit(None).cast("string"))
@@ -406,57 +418,59 @@ class TransactionHistoryViewETL(BaseETL):
             .withColumn("bucket_tx_count", F.lit(None).cast("long"))
             .withColumn("bucket_tx_amount", F.lit(None).cast("double"))
         )
-
+    
     def _build_agg(self, df: DataFrame, granularity: str) -> DataFrame:
         """Roll up entity rows to a given time granularity with deterministic PK."""
         bucket_start = F.date_trunc(granularity, F.col("event_ts"))
 
+        # Only aggregate actual payment instructions, not status reports
+        is_payment_tx = F.col("tx_type").isin(["pacs.008.001.10", "pain.001.001.11"])
+
         return (
             df.withColumn("bucket_start", bucket_start)
-        .groupBy("entity_type", "entity_role", "entity_id", "bucket_start")
-        .agg(
-            F.count("*").cast("long").alias("bucket_tx_count"),
-            F.sum(F.coalesce(F.col("tx_amount"), F.lit(0.0)))
-                .cast("double")
-                .alias("bucket_tx_amount"),
-            F.max("event_date").alias("event_date"),
-            F.max("tenant_id").alias("tenant_id"),
+            .filter(is_payment_tx)  # <-- EXCLUDE pacs.002 from aggregates
+            .groupBy("entity_type", "entity_role", "entity_id", "bucket_start")
+            .agg(
+                F.count("*").cast("long").alias("bucket_tx_count"),
+                F.sum(F.coalesce(F.col("tx_amount"), F.lit(0.0)))
+                    .cast("double")
+                    .alias("bucket_tx_amount"),
+                F.max("event_date").alias("event_date"),
+                F.max("tenant_id").alias("tenant_id"),
+            )
+            .withColumn("row_type", F.lit("AGG"))
+            .withColumn("bucket_granularity", F.lit(granularity))
+
+            .withColumn(
+                "transaction_id",
+                F.concat_ws(
+                     "||",
+                    F.lit("AGG"),
+                    F.col("entity_type"),
+                    F.col("entity_role"),
+                    F.col("entity_id"),
+                    F.col("bucket_granularity"),
+                    F.col("bucket_start").cast("string"),
+                ),
+            )
+
+            # Remaining columns (unchanged)
+            .withColumn("recent_rank_desc", F.lit(None).cast("int"))
+            .withColumn("cum_tx_count", F.lit(None).cast("long"))
+            .withColumn("cum_tx_amount", F.lit(None).cast("double"))
+            .withColumn("end_to_end_id", F.lit(None).cast("string"))
+            .withColumn("tx_type", F.lit(None).cast("string"))
+            .withColumn("tx_msg_id", F.lit(None).cast("string"))
+            .withColumn("event_ts", F.lit(None).cast("timestamp"))
+            .withColumn("tx_amount", F.lit(None).cast("double"))
+            .withColumn("tx_ccy", F.lit(None).cast("string"))
+            .withColumn("entity_name", F.lit(None).cast("string"))
+            .withColumn("is_alerted", F.lit(None).cast("int"))
+            .withColumn("is_investigated", F.lit(None).cast("int"))
+            .withColumn("source_file_path", F.lit(None).cast("string"))
+            .withColumn("record_hash", F.lit(None).cast("string"))
         )
-        .withColumn("row_type", F.lit("AGG"))
-        .withColumn("bucket_granularity", F.lit(granularity))
-
-        .withColumn(
-            "transaction_id",
-            F.concat_ws(
-                 "||",
-                F.lit("AGG"),
-                F.col("entity_type"),
-                F.col("entity_role"),
-                F.col("entity_id"),
-                F.col("bucket_granularity"),
-                F.col("bucket_start").cast("string"),
-            ),
-        )
-
-        # -------------------------------------------------------------
-        # Remaining columns (unchanged)
-        # -------------------------------------------------------------
-        .withColumn("recent_rank_desc", F.lit(None).cast("int"))
-        .withColumn("cum_tx_count", F.lit(None).cast("long"))
-        .withColumn("cum_tx_amount", F.lit(None).cast("double"))
-        .withColumn("end_to_end_id", F.lit(None).cast("string"))
-        .withColumn("tx_type", F.lit(None).cast("string"))
-        .withColumn("tx_msg_id", F.lit(None).cast("string"))
-        .withColumn("event_ts", F.lit(None).cast("timestamp"))
-        .withColumn("tx_amount", F.lit(None).cast("double"))
-        .withColumn("tx_ccy", F.lit(None).cast("string"))
-        .withColumn("entity_name", F.lit(None).cast("string"))
-        .withColumn("is_alerted", F.lit(None).cast("int"))
-        .withColumn("is_investigated", F.lit(None).cast("int"))
-        .withColumn("source_file_path", F.lit(None).cast("string"))
-        .withColumn("record_hash", F.lit(None).cast("string"))
-    )
-
+    
     def _add_pk(self, df: DataFrame) -> DataFrame:
         """Add unique record key for Hudi + ingestion timestamp.
 

--- a/automation-orchestrator/Table_ETLs/transaction_history_view.py
+++ b/automation-orchestrator/Table_ETLs/transaction_history_view.py
@@ -15,7 +15,7 @@ class TransactionHistoryViewETL(BaseETL):
     alerts/cases/tasks, expands to entity level, and writes event +
     day/week/month/year aggregate rows to Hudi.
 
-    Uses transaction_pk (TxTp||endToEndId) as the primary key.
+    Uses transaction_id (TxTp||endToEndId) as the primary key.
     """
 
     def __init__(self, spark, warehouse_root: str) -> None:
@@ -69,35 +69,133 @@ class TransactionHistoryViewETL(BaseETL):
         return df.withColumn("transaction_data", F.col(json_col).cast("string"))
 
     def _extract_base(self, df: DataFrame) -> DataFrame:
-        """Build the base transaction frame from parsed PACS JSON."""
-        tx_type = F.get_json_object("transaction_data", "$.TxTp")
+        """Build the base transaction frame from parsed PACS JSON.
+
+        Supports PACS.008, PACS.002, and pain.001 with DataCache fallbacks.
+        Uses regex as ultimate fallback since DataCache key names are stable
+        even when nesting varies.
+        """
+        # Use bronze tx_type if present, else fall back to JSON extraction
+        tx_type = F.coalesce(F.col("tx_type"), F.get_json_object("transaction_data", "$.TxTp"))
+
+        # --- Regex helpers (work regardless of JSON nesting) ---
+        _re = lambda key, grp=1: F.regexp_extract("transaction_data", rf'"{key}"\s*:\s*"([^"]+)"', grp)
+        _re_num = lambda key, grp=1: F.regexp_extract("transaction_data", rf'"{key}"\s*:\s*([0-9.]+)', grp)
+
+        # --- Message IDs & timestamps (get_json_object FIRST to avoid "" trap) ---
         tx_msg_id = F.coalesce(
             F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.GrpHdr.MsgId"),
             F.get_json_object("transaction_data", "$.FIToFIPmtSts.GrpHdr.MsgId"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.GrpHdr.MsgId"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.GrpHdr.MsgId"),
+            F.get_json_object("transaction_data", "$.DataCache.MsgId"),
+            _re("MsgId"),
+            _re("msgId"),
         )
         event_ts = F.to_timestamp(
             F.coalesce(
                 F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.GrpHdr.CreDtTm"),
                 F.get_json_object("transaction_data", "$.FIToFIPmtSts.GrpHdr.CreDtTm"),
+                F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.GrpHdr.CreDtTm"),
+                F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.GrpHdr.CreDtTm"),
+                F.get_json_object("transaction_data", "$.DataCache.CreDtTm"),
+                F.get_json_object("transaction_data", "$.DataCache.creDtTm"),
+                _re("CreDtTm"),
+                _re("creDtTm"),
             )
         )
         event_date = F.to_date(event_ts)
 
-        dbtr_name = F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Dbtr.Nm")
-        dbtr_id = F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Dbtr.Id.PrvtId.Othr[0].Id")
-        cdtr_name = F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Cdtr.Nm")
-        cdtr_id = F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Cdtr.Id.PrvtId.Othr[0].Id")
+        # --- Debtor / Creditor names ---
+        dbtr_name = F.coalesce(
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Dbtr.Nm"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.Dbtr.Nm"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.Dbtr.Nm"),
+            _re("dbtrId"),
+            F.get_json_object("transaction_data", "$.DataCache.dbtrId"),
+        )
+        cdtr_name = F.coalesce(
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Cdtr.Nm"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.Cdtr.Nm"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf.Cdtr.Nm"),
+            _re("cdtrId"),
+            F.get_json_object("transaction_data", "$.DataCache.cdtrId"),
+        )
 
-        dbtr_acct = F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.DbtrAcct.Id.Othr[0].Id")
-        cdtr_acct = F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.CdtrAcct.Id.Othr[0].Id")
+        # --- Debtor / Creditor IDs ---
+        dbtr_id = F.regexp_replace(
+            F.coalesce(
+                _re("dbtrId"),
+                F.get_json_object("transaction_data", "$.DataCache.dbtrId"),
+                F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Dbtr.Id.PrvtId.Othr[0].Id"),
+                F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Dbtr.Id.OrgId.Othr[0].Id"),
+                F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.Dbtr.Id.PrvtId.Othr[0].Id"),
+                F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.Dbtr.Id.OrgId.Othr[0].Id"),
+                F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.Dbtr.Id.PrvtId.Othr[0].Id"),
+                F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.Dbtr.Id.OrgId.Othr[0].Id"),
+            ),
+            "TAZAMA_EID$", "",
+        )
+        cdtr_id = F.regexp_replace(
+            F.coalesce(
+                _re("cdtrId"),
+                F.get_json_object("transaction_data", "$.DataCache.cdtrId"),
+                F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Cdtr.Id.PrvtId.Othr[0].Id"),
+                F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.Cdtr.Id.OrgId.Othr[0].Id"),
+                F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.Cdtr.Id.PrvtId.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.Cdtr.Id.OrgId.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf.Cdtr.Id.PrvtId.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf.Cdtr.Id.OrgId.Othr[0].Id"),
+            ),
+            "TAZAMA_EID$", "",
+        )
 
-        tx_amount = F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.InstdAmt.Amt.Amt").cast("double")
-        tx_ccy = F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.InstdAmt.Amt.Ccy")
+        # --- Account IDs (PACS.008 FIRST to match transaction_detail) ---
+        dbtr_acct = F.coalesce(
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.DbtrAcct.Id.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.DbtrAcct.Id.IBAN"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.DbtrAcct.Id.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.DbtrAcct.Id.IBAN"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.DbtrAcct.Id.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.DbtrAcct.Id.IBAN"),
+            F.get_json_object("transaction_data", "$.DataCache.dbtrAcctId"),
+            _re("dbtrAcctId"),
+        )
+        cdtr_acct = F.coalesce(
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.CdtrAcct.Id.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.CdtrAcct.Id.IBAN"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.CdtrAcct.Id.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.CdtrAcct.Id.IBAN"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf.CdtrAcct.Id.Othr[0].Id"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf.CdtrAcct.Id.IBAN"),
+            F.get_json_object("transaction_data", "$.DataCache.cdtrAcctId"),
+            _re("cdtrAcctId"),
+        )
+
+        # --- Amount & currency ---
+        tx_amount = F.coalesce(
+            _re_num("amt"),
+            F.get_json_object("transaction_data", "$.DataCache.instdAmt.amt"),
+            F.get_json_object("transaction_data", "$.DataCache.intrBkSttlmAmt.amt"),
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.InstdAmt.Amt.Amt"),
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.IntrBkSttlmAmt.Amt"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.InstdAmt.Amt.Amt"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf.Amt.InstdAmt.Amt"),
+        ).cast("double")
+        tx_ccy = F.coalesce(
+            _re("ccy"),
+            F.get_json_object("transaction_data", "$.DataCache.instdAmt.ccy"),
+            F.get_json_object("transaction_data", "$.DataCache.intrBkSttlmAmt.ccy"),
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.InstdAmt.Amt.Ccy"),
+            F.get_json_object("transaction_data", "$.FIToFICstmrCdtTrf.CdtTrfTxInf.IntrBkSttlmAmt.Ccy"),
+            F.get_json_object("transaction_data", "$.Document.FIToFICstmrCdtTrf.CdtTrfTxInf.InstdAmt.Amt.Ccy"),
+            F.get_json_object("transaction_data", "$.CstmrCdtTrfInitn.PmtInf.CdtTrfTxInf.Amt.InstdAmt.Ccy"),
+        )
 
         has_source = "source_file_path" in df.columns
         has_hash = "record_hash" in df.columns
 
-        return (
+        base = (
             df
             .withColumn("tx_type", tx_type)
             .withColumn("tx_msg_id", tx_msg_id)
@@ -111,8 +209,27 @@ class TransactionHistoryViewETL(BaseETL):
             .withColumn("cdtr_id", cdtr_id)
             .withColumn("dbtr_account_id", dbtr_acct)
             .withColumn("cdtr_account_id", cdtr_acct)
+        )
+
+        # Debug: log extraction coverage
+        total = base.count()
+        if total > 0:
+            stats = base.select(
+                F.sum(F.when(F.col("dbtr_id").isNotNull(), 1).otherwise(0)).alias("dbtr_id_ok"),
+                F.sum(F.when(F.col("cdtr_id").isNotNull(), 1).otherwise(0)).alias("cdtr_id_ok"),
+                F.sum(F.when(F.col("dbtr_account_id").isNotNull(), 1).otherwise(0)).alias("dbtr_acct_ok"),
+                F.sum(F.when(F.col("cdtr_account_id").isNotNull(), 1).otherwise(0)).alias("cdtr_acct_ok"),
+                F.sum(F.when(F.col("tx_amount").isNotNull(), 1).otherwise(0)).alias("amount_ok"),
+            ).collect()[0]
+            print(f"[TransactionHistoryViewETL] Extraction coverage out of {total} rows:")
+            print(f"  dbtr_id: {stats['dbtr_id_ok']}, cdtr_id: {stats['cdtr_id_ok']}")
+            print(f"  dbtr_account_id: {stats['dbtr_acct_ok']}, cdtr_account_id: {stats['cdtr_acct_ok']}")
+            print(f"  tx_amount: {stats['amount_ok']}")
+
+        return (
+            base
             .select(
-                F.col("transaction_pk").cast("string").alias("transaction_pk"),
+                F.col("transaction_id").cast("string").alias("transaction_id"),
                 F.col("end_to_end_id").cast("string").alias("end_to_end_id"),
                 F.col("tenant_id").cast("string").alias("tenant_id"),
                 F.col("tx_type").cast("string").alias("tx_type"),
@@ -313,7 +430,7 @@ class TransactionHistoryViewETL(BaseETL):
         .withColumn("bucket_granularity", F.lit(granularity))
 
         .withColumn(
-            "transaction_pk",
+            "transaction_id",
             F.concat_ws(
                  "||",
                 F.lit("AGG"),
@@ -345,8 +462,24 @@ class TransactionHistoryViewETL(BaseETL):
     )
 
     def _add_pk(self, df: DataFrame) -> DataFrame:
-        """Add ingestion timestamp. transaction_pk is carried forward as-is."""
-        return df.withColumn("ingested_at_ts", F.current_timestamp())
+        """Add unique record key for Hudi + ingestion timestamp.
+
+        transaction_id is kept as tx_type||end_to_end_id from bronze.
+        _record_key ensures each entity row is unique for Hudi upserts.
+        """
+        return (
+            df.withColumn(
+                "_record_key",
+                F.concat_ws(
+                    "||",
+                    F.col("transaction_id"),
+                    F.col("entity_type"),
+                    F.col("entity_role"),
+                    F.col("entity_id"),
+                ),
+            )
+            .withColumn("ingested_at_ts", F.current_timestamp())
+        )
 
     # ------------------------------------------------------------------
     # BRONZE  (main view build)
@@ -367,7 +500,7 @@ class TransactionHistoryViewETL(BaseETL):
         rename_map = {
             "endToEndId": "end_to_end_id",
             "tenantId": "tenant_id",
-            "transaction_pk": "transaction_pk",
+            "transaction_id": "transaction_id",
         }
         for src, dst in rename_map.items():
             if src in tx.columns and dst not in tx.columns:
@@ -395,7 +528,7 @@ class TransactionHistoryViewETL(BaseETL):
         # 8. Union all
         view_df = (
             events.select(
-                "transaction_pk",
+                "transaction_id",
                 "entity_type",
                 "entity_role",
                 "entity_id",
@@ -430,13 +563,13 @@ class TransactionHistoryViewETL(BaseETL):
         # 9. Ingest timestamp
         view_df = self._add_pk(view_df)
 
-        # 10. Write Hudi view — transaction_pk is the primary key
+        # 10. Write Hudi view — transaction_id is the primary key
         self.write_hudi(
             view_df,
             self.view_path,
             self.hudi_opts(
                 "vw_transaction_history",
-                record_key="transaction_pk",
+                record_key="_record_key",
                 precombine="ingested_at_ts",
             ),
         )

--- a/datalakehouse-api/lakehouse_query_api.py
+++ b/datalakehouse-api/lakehouse_query_api.py
@@ -125,6 +125,7 @@ alerts_nav_rules_path                 = f"{ALERT_NAV_ROOT}/rules_triggered"
 tx_detail_view_path                   = f"{VIEWS_ROOT}/vw_transaction_detail"
 tx_history_view_path                  = f"{VIEWS_ROOT}/vw_transaction_history"
 conditions_view_path                  = f"{VIEWS_ROOT}/conditions_timeline"
+alert_history_view_path                   = f"{VIEWS_ROOT}/alert_history"
 vw_tx_network_accounts_edges_path     = f"{VIEWS_ROOT}/vw_tx_network_accounts_edges"
 vw_tx_network_counterparties_edges_path = f"{VIEWS_ROOT}/vw_tx_network_counterparties_edges"
 vw_counterparty_account_links_path    = f"{VIEWS_ROOT}/vw_counterparty_account_links"
@@ -151,6 +152,7 @@ GOLD_PATHS = {
     "tx_network_accounts_edges":       vw_tx_network_accounts_edges_path,
     "tx_network_counterparties_edges": vw_tx_network_counterparties_edges_path,
     "counterparty_account_links":      vw_counterparty_account_links_path,
+    "alert_history":                   alert_history_view_path,
     
 }
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Updated the primary key references from transaction_pk to transaction_id

## Why are we doing this?
Transaction View were partially failing due to the wrong referencing. 

## How was it tested?
- [ ] Locally
- [ x ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized transaction identifier to transaction_id across pipelines and views
  * Applied date-based partitioning and overwrite payload strategy for staged dataset writes
  * Expanded extraction to support more PACS message formats with stronger fallbacks and coverage metrics

* **New Features**
  * Rules pipeline refactored to emit nested substructures as JSON strings and simplified Gold schema
  * Added an alert_history Gold view for querying alert history

* **Bug Fixes**
  * Removed now-unused typology description from Silver/Gold outputs

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/biar/pull/51)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->