### PR TITLE
fix: pacs002 partitioning for silver table

### DIFF
--- a/automation-orchestrator/Table_ETLs/Pacs002ETL.py
+++ b/automation-orchestrator/Table_ETLs/Pacs002ETL.py
@@ -155,7 +155,7 @@ class Pacs002ETL(BaseETL):
         self.write_hudi(
             silver,
             self.silver_path,
-            self.hudi_opts("silver_pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date",
+            self.hudi_opts("silver_pacs002", "end_to_end_id", "ingested_at_ts", partition="event_date_silver",
                 payload_class="org.apache.hudi.common.model.OverwriteWithLatestAvroPayload"),
         )
         print(f"[Pacs002ETL] Silver written → {self.silver_path}")


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Update Hudi partitioning for silver path in Pacs002ETL

## Why are we doing this?
Partition mismatch of pacs002 silver

## How was it tested?
- [ ] Locally
- [ x ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done