### PR TITLE
fix(ci): backport Slack Docker notification source-PR and image-link updates [skip ci]

### DIFF
--- a/.github/workflows/dockerhub-image-build-multi-rc.yml
+++ b/.github/workflows/dockerhub-image-build-multi-rc.yml
@@ -70,12 +70,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-automation-orchestrator "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-automation-orchestrator "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-automation-orchestrator>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_datalakehouse_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -126,12 +139,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-datalakehouse-api "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-datalakehouse-api "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-datalakehouse-api>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_jupyterlab_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -182,12 +208,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-jupyterlab "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-jupyterlab "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-jupyterlab>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_unstructured_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -240,12 +279,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-unstructured-pipeline "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-unstructured-pipeline "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-unstructured-pipeline>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_nifi_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -296,9 +348,22 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-nifi "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-nifi "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-nifi>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/dockerhub-image-build-multi.yml
+++ b/.github/workflows/dockerhub-image-build-multi.yml
@@ -74,12 +74,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-automation-orchestrator "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-automation-orchestrator "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-automation-orchestrator>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_datalakehouse:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -133,12 +146,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-datalakehouse-api "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-datalakehouse-api "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-datalakehouse-api>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_jupyterlab:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -192,12 +218,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-jupyterlab "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-jupyterlab "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-jupyterlab>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_unstructured:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -253,12 +292,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-unstructured-pipeline "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-unstructured-pipeline "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-unstructured-pipeline>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_nifi:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -312,9 +364,22 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-nifi "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-nifi "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-nifi>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL


### PR DESCRIPTION
## Summary
Backports the Slack Docker notification improvements from workflows PR #143 into this repo's multi image publish workflows.

## Changes
- Added `Resolve source PR` step in both workflow files for each publish job.
- Changed DockerHub link from org listing to image-specific repository URL.
- Added conditional `Source PR` field in Slack message payload.
- Kept notification and PR-resolution steps non-fatal.

## Files
- `.github/workflows/dockerhub-image-build-multi.yml`
- `.github/workflows/dockerhub-image-build-multi-rc.yml`

## Verification
- Confirmed all org-level DockerHub URLs are removed.
- Confirmed Source PR field injection exists for each Slack notification block.

Refs #87
