### PR TITLE
fix(ci): use GH_TOKEN_LIB for package auth in CI and image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 
       - name: Build
         run: npm run build
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 
       - name: Lint
         run: npm run lint
@@ -76,7 +76,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 
       - name: Run tests
         run: npm test
@@ -139,7 +139,7 @@ jobs:
           file: ./unstructured-pipeline/Dockerfile
           push: false
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Build nifi
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294

--- a/.github/workflows/dockerhub-image-build-multi-rc.yml
+++ b/.github/workflows/dockerhub-image-build-multi-rc.yml
@@ -269,7 +269,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Generate artifact attestation
         continue-on-error: true

--- a/.github/workflows/dockerhub-image-build-multi.yml
+++ b/.github/workflows/dockerhub-image-build-multi.yml
@@ -283,7 +283,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           secrets: |
-            GH_TOKEN=${{ secrets.GH_TOKEN }}
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32


### PR DESCRIPTION
## What

Point every private-package auth site in biar's bespoke CI/publish workflows at `GH_TOKEN_LIB` instead of `GH_TOKEN`.

## Why

As part of SEC-2026-002 the org-level `GH_TOKEN` was re-scoped to a fine-grained sync-workflows token with **no `read:packages` scope**. Every step that installs private `@tazama-lf` packages via `secrets.GH_TOKEN` now 403s.

`GH_TOKEN_LIB` is the dedicated `read:packages` token and is the correct source for package authentication. `GH_TOKEN` is intentionally left un-broadened.

## Change

Only the **value source** changes (`secrets.GH_TOKEN` -> `secrets.GH_TOKEN_LIB`). The BuildKit mount id and the env var name remain `GH_TOKEN`, so no Dockerfile or `.npmrc` changes are required.

Six sites across three workflows:

| File | Sites | Kind |
|---|---|---|
| `dockerhub-image-build-multi.yml` | 1 | `secrets:` build mount (unstructured-pipeline publish) |
| `dockerhub-image-build-multi-rc.yml` | 1 | `secrets:` build mount (rc publish) |
| `ci.yml` | 1 + 3 | 1 build mount + 3 runner `npm ci` `env: GH_TOKEN` steps (Build / Lint / Test jobs) |

The three `env: GH_TOKEN` on the runner `npm ci` steps install private deps directly on the runner and would 403 the same way, so they get the same fix. Env var name kept as `GH_TOKEN`.

## Verification

- 0 non-LIB `secrets.GH_TOKEN` references remain.
- Diff: `ci.yml` 8 lines, `dockerhub-image-build-multi-rc.yml` 2, `dockerhub-image-build-multi.yml` 2.
