### PR TITLE
fix: Remove tenantId

### DIFF
--- a/automation-orchestrator/Table_ETLs/alert_navigator.py
+++ b/automation-orchestrator/Table_ETLs/alert_navigator.py
@@ -484,8 +484,7 @@ class AlertNavigatorETL(BaseETL):
                 "network_message_cfg",
                 "network_tx_type",
                 F.col("t.id").alias("typology_id"),
-                F.col("t.cfg").alias("typology_cfg"),
-                F.col("t.tenantId").alias("typology_tenant_id"),
+                F.col("t.cfg").alias("typology_cfg"),              
                 F.explode_outer(F.col("t.rules")).alias("r"),
             )
             .select(


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Just remove tenantId from `_build_network_eval` from BIAR.
## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected network evaluation output to use the appropriate typology configuration data.
  * Removed an incorrectly included tenant identifier from the generated typology fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->