### PR TITLE
fix: carry tenant_id through SlaEscalationRecordsETL bronze/silver/gold

### DIFF
--- a/automation-orchestrator/Table_ETLs/SlaEscalationRecordsETL.py
+++ b/automation-orchestrator/Table_ETLs/SlaEscalationRecordsETL.py
@@ -33,6 +33,7 @@ class SlaEscalationRecordsETL(BaseETL):
         bronze = (
             raw
             .withColumn("id", F.col("id").cast("long"))
+            .withColumn("tenant_id", F.col("tenant_id").cast("string"))
             .withColumn("case_id", F.col("case_id").cast("long"))
             .withColumn("notified_at", F.col("notified_at").cast("long"))
             .withColumn("sla_state", F.col("sla_state").cast("string"))
@@ -55,6 +56,7 @@ class SlaEscalationRecordsETL(BaseETL):
         silver = (
             b
             .withColumn("id", F.col("id").cast("long"))
+            .withColumn("tenant_id", F.col("tenant_id").cast("string"))
             .withColumn("case_id", F.col("case_id").cast("long"))
             .withColumn("notified_at", F.col("notified_at").cast("long"))
             .withColumn("sla_state", F.upper(F.col("sla_state").cast("string")))
@@ -78,6 +80,7 @@ class SlaEscalationRecordsETL(BaseETL):
 
         gold = s.select(
             F.col("id").cast("long").alias("id"),
+            F.col("tenant_id").cast("string").alias("tenant_id"),
             F.col("case_id").cast("long").alias("case_id"),
             F.col("notified_at").cast("long").alias("notified_at"),
             F.col("notified_at_ts").cast("timestamp").alias("notified_at_ts"),


### PR DESCRIPTION
The gold projection for sla_escalation_records dropped tenant_id, and bronze/silver did not normalise its type. Downstream tenant-scoped consumers (Lakehouse Catalog notebook's `load_tenant_hudi`) then failed with `ValueError` because `gold/sla_escalation_records` had no tenant filter column.

Cast `tenant_id` as string in bronze and silver, and re-select it in gold, matching the pattern already used by `SlaEscalationThresholdsETL` and other tenant-scoped ETLs in the same directory.

Refs: tazama-lf/biar#127

# SPDX-License-Identifier: Apache-2.0

## What did we change?

`automation-orchestrator/Table_ETLs/SlaEscalationRecordsETL.py`:
- `bronze()` — added `.withColumn("tenant_id", F.col("tenant_id").cast("string"))` so the column is explicitly normalised alongside the other casts.
- `silver()` — same cast added to keep the type stable through the silver stage.
- `gold()` — added `F.col("tenant_id").cast("string").alias("tenant_id")` to the explicit `select(...)` projection so the column survives into gold.

No changes to NiFi flow, ODS schema, or any other ETL — `tenant_id` is already emitted by the NiFi `QueryDatabaseTableRecord` processor (empty `Columns to Return` pulls all source columns) and confirmed present on the ODS `tazama_cms.sla_escalation_records` table (`text NOT NULL`, indexed).

## Why are we doing this?

The Lakehouse Catalog notebook filters every Hudi table it loads by tenant via `load_tenant_hudi`, which expects one of `("tenant_id", "tx_tenant_id", "tenantid")` to be present. Because `SlaEscalationRecordsETL` used an explicit gold `select(...)` that did not include `tenant_id`, the column was dropped between silver and gold and the notebook raised:

```
ValueError: Hudi table at /opt/Tazama_Warehouse/gold/sla_escalation_records has no tenant filter column; expected one of ('tenant_id', 'tx_tenant_id', 'tenantid')
```


This blocked the notebook and any tenant-scoped query or view over SLA escalation records. The fix aligns this ETL with the tenant-carrying pattern already used by peer ETLs (`CasesETL`, `TasksETL`, `SlaEscalationThresholdsETL`), so no new convention is introduced.

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done

Local verification:
- `python -m py_compile` on the modified ETL — passes.
- Diffed against `SlaEscalationThresholdsETL` bronze/silver/gold to confirm the cast/select placement matches the established pattern.
- Read-only check against the UAT ODS (`tazama-extensions-postgres-1` on host `tazama-b`, database `tazama_cms`): confirmed `sla_escalation_records.tenant_id` exists as `text NOT NULL` with a dedicated index, and 59 rows across 1 tenant are present — so the Spark `F.col("tenant_id").cast("string")` will resolve against real source data.
- Confirmed no other consumers need updating: only `lakehouse_automation_pipeline.py` (dispatch-only, no change needed) and `nifi/tazama.xml` (already emits all columns) reference this table; no dashboards, API code, SQL/DDL, or tests reference it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Processing**
  * Improved SLA escalation record processing to consistently retain tenant identifiers across all data stages.
  * Ensured tenant identifiers are stored in a consistent text format for reliable downstream use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->