### PR TITLE
fix: correct DockerHub image name for JupyterHub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,9 +89,8 @@ NIFI_WEB_HTTP_HOST=0.0.0.0
 # -----------------------
 # JupyterHub Configuration
 # -----------------------
-JUPYTERHUB_PORT=8000
+JUPYTERHUB_PORT=8888
 JUPYTERHUB_ADMIN=admin
-JUPYTERLAB_PORT=8888
 
 # -----------------------
 # Unstructured-Pipeline Configuration

--- a/.github/workflows/dockerhub-image-build-multi-rc.yml
+++ b/.github/workflows/dockerhub-image-build-multi-rc.yml
@@ -40,7 +40,7 @@ jobs:
             dockerfile: ./datalakehouse-api/Dockerfile
             pass_lib_token: false
 
-          - image_suffix: jupyterlab
+          - image_suffix: jupyterhub
             context: ./JupyterHub
             dockerfile: ./JupyterHub/Dockerfile
             pass_lib_token: false

--- a/.github/workflows/dockerhub-image-build-multi.yml
+++ b/.github/workflows/dockerhub-image-build-multi.yml
@@ -41,7 +41,7 @@ jobs:
             dockerfile: ./datalakehouse-api/Dockerfile
             pass_lib_token: false
 
-          - image_suffix: jupyterlab
+          - image_suffix: jupyterhub
             context: ./JupyterHub
             dockerfile: ./JupyterHub/Dockerfile
             pass_lib_token: false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -224,16 +224,16 @@ services:
     depends_on:
       - s3g
 
-  jupyterlab:
+  jupyterhub:
     build:
       context: ./JupyterHub
       dockerfile: Dockerfile
-    container_name: biar-jupyterlab
+    container_name: biar-jupyterhub
     restart: unless-stopped
     env_file:
       - .env
     ports:
-      - "${JUPYTERLAB_PORT}:8000"
+      - "${JUPYTERHUB_PORT}:8000"
     volumes:
       - ./JupyterHub/notebooks:/srv/notebooks
       - ${TAZAMA_WAREHOUSE_HOST_PATH}:/opt/Tazama_Warehouse


### PR DESCRIPTION
# Fix DockerHub image name for JupyterHub (and align related naming)

## Problem

Both multi-image DockerHub build workflows set the `image_suffix` for the JupyterHub service to `jupyterlab`, producing an incorrectly named published image (`tazamaorg/biar-jupyterlab`) that does not match the service it builds (context `./JupyterHub`, `JupyterHub/Dockerfile`, container command `jupyterhub`).

The same `jupyterlab` misnomer had also leaked into the local compose stack and env template, even though the service runs JupyterHub.

## Changes

**Image name fix (the bug):**
- Corrected `image_suffix` from `jupyterlab` to `jupyterhub` in `.github/workflows/dockerhub-image-build-multi.yml` and `.github/workflows/dockerhub-image-build-multi-rc.yml`. The published image is now `tazamaorg/biar-jupyterhub`.

**Naming alignment (consistency cleanup):**
- Renamed the compose service `jupyterlab` -> `jupyterhub` and `container_name` `biar-jupyterlab` -> `biar-jupyterhub` in `docker-compose.yaml`.
- Consolidated onto a single `JUPYTERHUB_PORT` host-port variable and removed the redundant `JUPYTERLAB_PORT` in `.env.example`.
- Corrected `JUPYTERHUB_PORT` to `8888` (the documented host port). It was previously `8000` (the container port) and unused.

The host-to-container port mapping (`8888:8000`) and the README are unchanged.

## Heads-up for reviewers / downstream

Renaming the published image means the next release publishes a new `tazamaorg/biar-jupyterhub` repository on Docker Hub, and the old `tazamaorg/biar-jupyterlab` becomes orphaned. Any external deployment (deploy/helm/compose repos outside this repo) that references `tazamaorg/biar-jupyterlab` must be updated to `tazamaorg/biar-jupyterhub`.

## Testing

- Changes are limited to CI workflow matrix values, the compose service definition, and the env template; no runtime/application code is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JupyterHub service naming across deployment configuration and container builds.
  * Fixed generated Docker image tags to use the JupyterHub label instead of JupyterLab.
  * Updated the default JupyterHub port configuration to 8888 and removed the outdated JupyterLab port setting.
  * The service is now exposed through the configured JupyterHub port while continuing to run internally on port 8000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->