### PR TITLE
ci: root package.json version source, latest tag, dispatch and layer caching for multi Docker builds

### DIFF
--- a/.github/workflows/dockerhub-image-build-multi-rc.yml
+++ b/.github/workflows/dockerhub-image-build-multi-rc.yml
@@ -112,6 +112,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image_suffix }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image_suffix }}
           secrets: |
             GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
@@ -125,6 +127,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image_suffix }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image_suffix }}
 
       - name: Resolve image digest
         id: digest

--- a/.github/workflows/dockerhub-image-build-multi.yml
+++ b/.github/workflows/dockerhub-image-build-multi.yml
@@ -11,7 +11,8 @@
 
 # This workflow is for the BIAR repository which produces multiple Docker images,
 # each built from its own subdirectory via a build matrix.
-# All images share the version from unstructured-pipeline/package.json.
+# All images share the version from the ROOT package.json - the single platform
+# version stamped by the release train.
 
 name: Publish Docker images (multi)
 
@@ -20,6 +21,7 @@ on:
     branches: [ "main" ]
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish_images:
@@ -86,7 +88,7 @@ jobs:
 
       - name: Get package version
         id: pkg_version
-        run: echo "VERSION=$(node -p "require('./unstructured-pipeline/package.json').version")" >> "$GITHUB_OUTPUT"
+        run: echo "VERSION=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Resolve source PR
         id: src_pr
@@ -106,6 +108,7 @@ jobs:
           images: ${{ env.IMAGE_REPOSITORY }}
           tags: |
             type=raw,value=${{ steps.pkg_version.outputs.VERSION }}
+            type=raw,value=latest
 
       - name: Build and push ${{ matrix.image_suffix }} Docker image (with lib token)
         if: matrix.pass_lib_token
@@ -117,6 +120,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image_suffix }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image_suffix }}
           secrets: |
             GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
@@ -130,6 +135,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image_suffix }}
+          cache-to: type=gha,mode=min,scope=${{ matrix.image_suffix }}
 
       - name: Resolve image digest
         id: digest

--- a/JupyterHub/Dockerfile
+++ b/JupyterHub/Dockerfile
@@ -27,7 +27,8 @@ ARG HADOOP_AWS_VERSION=3.3.4
 ARG AWS_SDK_BUNDLE_VERSION=1.12.262
 
 RUN mkdir -p /opt /opt/jars && \
-    curl -fsSL "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz && \
+    { curl -fsSL "https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz || \
+      curl -fsSL "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz; } && \
     tar -xzf /tmp/spark.tgz -C /opt && \
     mv "/opt/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}" /opt/spark && \
     rm -f /tmp/spark.tgz

--- a/automation-orchestrator/Dockerfile
+++ b/automation-orchestrator/Dockerfile
@@ -25,7 +25,8 @@ ARG HADOOP_AWS_VERSION=3.3.4
 ARG AWS_SDK_BUNDLE_VERSION=1.12.262
 
 RUN mkdir -p /opt /opt/jars && \
-    curl -fsSL "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz && \
+    { curl -fsSL "https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz || \
+      curl -fsSL "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz; } && \
     tar -xzf /tmp/spark.tgz -C /opt && \
     mv "/opt/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}" /opt/spark && \
     rm -f /tmp/spark.tgz

--- a/datalakehouse-api/Dockerfile
+++ b/datalakehouse-api/Dockerfile
@@ -28,7 +28,8 @@ ENV SPARK_JARS=/opt/jars/hudi-spark3.4-bundle_2.12-0.14.1.jar
 WORKDIR /app
 
 RUN mkdir -p /opt && \
-    curl -fL# "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz && \
+    { curl -fL# "https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz || \
+      curl -fL# "https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}.tgz" -o /tmp/spark.tgz; } && \
     tar -xzf /tmp/spark.tgz -C /opt && \
     mv "/opt/spark-${SPARK_VERSION}-bin-${HADOOP_PROFILE}" /opt/spark && \
     rm -f /tmp/spark.tgz

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "biar",
+  "private": true,
+  "version": "4.0.0-rc.0"
+}


### PR DESCRIPTION
Implements tazama-lf/biar#149 - makes biar structurally compatible with the release train, fixes the stable multi image workflow, and bundles the two build-speed items from #142.

Resolves #149

## Changes (one commit per logical unit)

### 1. `build: add minimal root package.json as the platform version source`

- New minimal private root manifest, `version` stamped `4.0.0-rc.0` - joining the in-flight v4.0.0 rc line (matches `unstructured-pipeline/package.json`) for an idempotent `4.0.0` re-release.
- `dev` ONLY by design: no retro-stamp of `main` (add/add merge-conflict risk on the next release PR); `main` receives the file naturally at the next dev->main release merge. The next release becomes biar's first full end-to-end release-train test.

### 2. `ci: version multi images from root, tag latest, add dispatch and layer caching`

`dockerhub-image-build-multi.yml` (stable):
- `pkg_version` reads the ROOT `./package.json` (was `unstructured-pipeline/package.json`, which the release train never stamps - why release-day images carried `4.0.0-rc.0`).
- `type=raw,value=latest` added to the metadata-action tags (same defect as the central variants, tazama-lf/workflows#171).
- `workflow_dispatch:` trigger added (release-free rebuild path).

BOTH multi variants (stable + rc):
- GHA layer caching: `cache-from: type=gha` / `cache-to: type=gha,mode=min` with a per-image `scope` (matrix jobs would otherwise fight over the default scope). `mode=min` per the 10 GB repo cache cap vs three ~2.4 GB Spark images.

RC tag semantics untouched (floating `rc` tag preserved). No checkout `ref` pin - default-branch fallback to `main` is correct for stable builds.

### 3. `build: prefer dlcdn.apache.org for Spark downloads with archive fallback`

- The three Spark-stack Dockerfiles (`automation-orchestrator`, `datalakehouse-api`, `JupyterHub`) now try `dlcdn.apache.org` first and fall back to `archive.apache.org`.
- **Discovered during implementation**: Spark 3.4.2 is already archive-only (dlcdn 404s; the CDN carries only 3.5.8/3.5.9 - verified 2026-07-24). Today every build takes the fallback path; the swap pays off at the next Spark version bump. The layer cache in commit 2 is what actually shortens the dispatch-test loop right now.

## Not in this PR

- NO image rebuild - all 5 `biar-*` images already carry `4.0.0` + `latest` (backfilled 2026-07-23).
- Shared Spark base image - #142 item 3, tracked there.
- `unstructured-pipeline/package.json` already reads `4.0.0-rc.0` (== root), no alignment needed.

## Verification plan (post-merge)

- Push to dev fires the rc multi workflow - first dispatch/push populates the GHA cache, a second run should show cache hits on the Spark layers.
- Stable path is exercised at the v4.0.0 re-release (push:main) - 5 images at `4.0.0` + `latest` from the root version.

Part of the v4.0.0 Docker image tag remediation (docker-image-remediation-plan.md, item 2).
