### PR TITLE
ci: set up the buildx driver for GHA cache export in multi builds

### DIFF
--- a/.github/workflows/dockerhub-image-build-multi-rc.yml
+++ b/.github/workflows/dockerhub-image-build-multi-rc.yml
@@ -71,6 +71,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+
       - name: Set ENV variables
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}"

--- a/.github/workflows/dockerhub-image-build-multi.yml
+++ b/.github/workflows/dockerhub-image-build-multi.yml
@@ -74,6 +74,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+
       - name: Set ENV variables
         run: |
           REPO_NAME="${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}"


### PR DESCRIPTION
Fixes the regression from #150 that failed all 5 RC image builds (run [30085571884](https://github.com/tazama-lf/biar/actions/runs/30085571884)):

```
ERROR: failed to build: Cache export is not supported for the docker driver.
```

Resolves #151

## Root cause

The GHA layer caching added in #150 (`cache-from`/`cache-to: type=gha`) requires the **buildx driver**, but neither multi workflow had a `docker/setup-buildx-action` step - `docker/build-push-action` fell back to the default `docker` driver, which cannot export cache. The stable variant carries the identical defect and would fail the same way at the v4.0.0 re-release.

## Change

Add the `docker/setup-buildx-action` step (SHA-pinned `8d2750c6...` v3.12.0 - the same pin biar's `ci.yml` already uses) between login and build in BOTH:

- `.github/workflows/dockerhub-image-build-multi.yml` (stable)
- `.github/workflows/dockerhub-image-build-multi-rc.yml`

## Verification

The RC workflow fires on merge to dev (push trigger) - first run rebuilds all 5 images and seeds the cache (expect full-length builds); subsequent runs should show `importing cache manifest` in the logs and shorter build times.
